### PR TITLE
PTV-571: removed line that changes contig_ids

### DIFF
--- a/lib/kb_cufflinks/core/contig_id_mapping.py
+++ b/lib/kb_cufflinks/core/contig_id_mapping.py
@@ -113,8 +113,9 @@ def replace_gff_contig_ids(gff_filename=None, mapping_filename=None, to_modified
                 temp_gff.write(line)
             else:
                 contig_id = line.split()[0]
-                modified_line = line.replace(contig_id, contig_id_mapping[contig_id])
-                temp_gff.write(modified_line)
+                #modified_line = line.replace(contig_id, contig_id_mapping[contig_id])
+                #temp_gff.write(modified_line)
+                temp_gff.write(line)
                 
             line = gff_data.readline()
     


### PR DESCRIPTION
The contig ids were being changed in the gtf file and this caused all FPKM values to go to 0 as if nothing was being mapped by the aligners. 