### PR TITLE
TASK-1178 Changes to use ref chains for alignments in input sets.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,3 +3,6 @@
 
 ### Version 0.0.1
 - Contains narrative interfaces for two apps - Cufflinks and Cuffdiff.
+
+### Version 0.1.0
+- Module updated to handle ref chains for the alignment objects in the input alignment set

--- a/kbase.yml
+++ b/kbase.yml
@@ -9,7 +9,7 @@ service-language:
     python
 
 module-version:
-    0.0.2
+    0.1.0
 
 owners:
     [umaganapathyswork, arfath]

--- a/lib/SetAPI/SetAPIClient.py
+++ b/lib/SetAPI/SetAPIClient.py
@@ -15,7 +15,6 @@ try:
 except:
     # no they aren't
     from baseclient import BaseClient as _BaseClient  # @Reimport
-import time
 
 
 class SetAPI(object):
@@ -25,28 +24,16 @@ class SetAPI(object):
             password=None, token=None, ignore_authrc=False,
             trust_all_ssl_certificates=False,
             auth_svc='https://kbase.us/services/authorization/Sessions/Login',
-            service_ver='release',
-            async_job_check_time_ms=100, async_job_check_time_scale_percent=150, 
-            async_job_check_max_time_ms=300000):
+            service_ver='release'):
         if url is None:
-            raise ValueError('A url is required')
+            url = 'https://kbase.us/services/service_wizard'
         self._service_ver = service_ver
         self._client = _BaseClient(
             url, timeout=timeout, user_id=user_id, password=password,
             token=token, ignore_authrc=ignore_authrc,
             trust_all_ssl_certificates=trust_all_ssl_certificates,
             auth_svc=auth_svc,
-            async_job_check_time_ms=async_job_check_time_ms,
-            async_job_check_time_scale_percent=async_job_check_time_scale_percent,
-            async_job_check_max_time_ms=async_job_check_max_time_ms)
-
-    def _check_job(self, job_id):
-        return self._client._check_job('SetAPI', job_id)
-
-    def _get_differential_expression_matrix_set_v1_submit(self, params, context=None):
-        return self._client._submit_job(
-             'SetAPI.get_differential_expression_matrix_set_v1', [params],
-             self._service_ver, context)
+            lookup_url=True)
 
     def get_differential_expression_matrix_set_v1(self, params, context=None):
         """
@@ -163,22 +150,9 @@ class SetAPI(object):
            key-value pairs provided by the user.) -> mapping from String to
            String
         """
-        job_id = self._get_differential_expression_matrix_set_v1_submit(params, context)
-        async_job_check_time = self._client.async_job_check_time
-        while True:
-            time.sleep(async_job_check_time)
-            async_job_check_time = (async_job_check_time *
-                self._client.async_job_check_time_scale_percent / 100.0)
-            if async_job_check_time > self._client.async_job_check_max_time:
-                async_job_check_time = self._client.async_job_check_max_time
-            job_state = self._check_job(job_id)
-            if job_state['finished']:
-                return job_state['result'][0]
-
-    def _save_differential_expression_matrix_set_v1_submit(self, params, context=None):
-        return self._client._submit_job(
-             'SetAPI.save_differential_expression_matrix_set_v1', [params],
-             self._service_ver, context)
+        return self._client.call_method(
+            'SetAPI.get_differential_expression_matrix_set_v1',
+            [params], self._service_ver, context)
 
     def save_differential_expression_matrix_set_v1(self, params, context=None):
         """
@@ -294,22 +268,9 @@ class SetAPI(object):
            key-value pairs provided by the user.) -> mapping from String to
            String
         """
-        job_id = self._save_differential_expression_matrix_set_v1_submit(params, context)
-        async_job_check_time = self._client.async_job_check_time
-        while True:
-            time.sleep(async_job_check_time)
-            async_job_check_time = (async_job_check_time *
-                self._client.async_job_check_time_scale_percent / 100.0)
-            if async_job_check_time > self._client.async_job_check_max_time:
-                async_job_check_time = self._client.async_job_check_max_time
-            job_state = self._check_job(job_id)
-            if job_state['finished']:
-                return job_state['result'][0]
-
-    def _get_feature_set_set_v1_submit(self, params, context=None):
-        return self._client._submit_job(
-             'SetAPI.get_feature_set_set_v1', [params],
-             self._service_ver, context)
+        return self._client.call_method(
+            'SetAPI.save_differential_expression_matrix_set_v1',
+            [params], self._service_ver, context)
 
     def get_feature_set_set_v1(self, params, context=None):
         """
@@ -421,22 +382,9 @@ class SetAPI(object):
            metadata about an object. Arbitrary key-value pairs provided by
            the user.) -> mapping from String to String
         """
-        job_id = self._get_feature_set_set_v1_submit(params, context)
-        async_job_check_time = self._client.async_job_check_time
-        while True:
-            time.sleep(async_job_check_time)
-            async_job_check_time = (async_job_check_time *
-                self._client.async_job_check_time_scale_percent / 100.0)
-            if async_job_check_time > self._client.async_job_check_max_time:
-                async_job_check_time = self._client.async_job_check_max_time
-            job_state = self._check_job(job_id)
-            if job_state['finished']:
-                return job_state['result'][0]
-
-    def _save_feature_set_set_v1_submit(self, params, context=None):
-        return self._client._submit_job(
-             'SetAPI.save_feature_set_set_v1', [params],
-             self._service_ver, context)
+        return self._client.call_method(
+            'SetAPI.get_feature_set_set_v1',
+            [params], self._service_ver, context)
 
     def save_feature_set_set_v1(self, params, context=None):
         """
@@ -549,22 +497,9 @@ class SetAPI(object):
            key-value pairs provided by the user.) -> mapping from String to
            String
         """
-        job_id = self._save_feature_set_set_v1_submit(params, context)
-        async_job_check_time = self._client.async_job_check_time
-        while True:
-            time.sleep(async_job_check_time)
-            async_job_check_time = (async_job_check_time *
-                self._client.async_job_check_time_scale_percent / 100.0)
-            if async_job_check_time > self._client.async_job_check_max_time:
-                async_job_check_time = self._client.async_job_check_max_time
-            job_state = self._check_job(job_id)
-            if job_state['finished']:
-                return job_state['result'][0]
-
-    def _get_expression_set_v1_submit(self, params, context=None):
-        return self._client._submit_job(
-             'SetAPI.get_expression_set_v1', [params],
-             self._service_ver, context)
+        return self._client.call_method(
+            'SetAPI.save_feature_set_set_v1',
+            [params], self._service_ver, context)
 
     def get_expression_set_v1(self, params, context=None):
         """
@@ -679,22 +614,9 @@ class SetAPI(object):
            key-value pairs provided by the user.) -> mapping from String to
            String
         """
-        job_id = self._get_expression_set_v1_submit(params, context)
-        async_job_check_time = self._client.async_job_check_time
-        while True:
-            time.sleep(async_job_check_time)
-            async_job_check_time = (async_job_check_time *
-                self._client.async_job_check_time_scale_percent / 100.0)
-            if async_job_check_time > self._client.async_job_check_max_time:
-                async_job_check_time = self._client.async_job_check_max_time
-            job_state = self._check_job(job_id)
-            if job_state['finished']:
-                return job_state['result'][0]
-
-    def _save_expression_set_v1_submit(self, params, context=None):
-        return self._client._submit_job(
-             'SetAPI.save_expression_set_v1', [params],
-             self._service_ver, context)
+        return self._client.call_method(
+            'SetAPI.get_expression_set_v1',
+            [params], self._service_ver, context)
 
     def save_expression_set_v1(self, params, context=None):
         """
@@ -809,22 +731,9 @@ class SetAPI(object):
            key-value pairs provided by the user.) -> mapping from String to
            String
         """
-        job_id = self._save_expression_set_v1_submit(params, context)
-        async_job_check_time = self._client.async_job_check_time
-        while True:
-            time.sleep(async_job_check_time)
-            async_job_check_time = (async_job_check_time *
-                self._client.async_job_check_time_scale_percent / 100.0)
-            if async_job_check_time > self._client.async_job_check_max_time:
-                async_job_check_time = self._client.async_job_check_max_time
-            job_state = self._check_job(job_id)
-            if job_state['finished']:
-                return job_state['result'][0]
-
-    def _get_reads_alignment_set_v1_submit(self, params, context=None):
-        return self._client._submit_job(
-             'SetAPI.get_reads_alignment_set_v1', [params],
-             self._service_ver, context)
+        return self._client.call_method(
+            'SetAPI.save_expression_set_v1',
+            [params], self._service_ver, context)
 
     def get_reads_alignment_set_v1(self, params, context=None):
         """
@@ -940,22 +849,9 @@ class SetAPI(object):
            key-value pairs provided by the user.) -> mapping from String to
            String
         """
-        job_id = self._get_reads_alignment_set_v1_submit(params, context)
-        async_job_check_time = self._client.async_job_check_time
-        while True:
-            time.sleep(async_job_check_time)
-            async_job_check_time = (async_job_check_time *
-                self._client.async_job_check_time_scale_percent / 100.0)
-            if async_job_check_time > self._client.async_job_check_max_time:
-                async_job_check_time = self._client.async_job_check_max_time
-            job_state = self._check_job(job_id)
-            if job_state['finished']:
-                return job_state['result'][0]
-
-    def _save_reads_alignment_set_v1_submit(self, params, context=None):
-        return self._client._submit_job(
-             'SetAPI.save_reads_alignment_set_v1', [params],
-             self._service_ver, context)
+        return self._client.call_method(
+            'SetAPI.get_reads_alignment_set_v1',
+            [params], self._service_ver, context)
 
     def save_reads_alignment_set_v1(self, params, context=None):
         """
@@ -1071,22 +967,9 @@ class SetAPI(object):
            key-value pairs provided by the user.) -> mapping from String to
            String
         """
-        job_id = self._save_reads_alignment_set_v1_submit(params, context)
-        async_job_check_time = self._client.async_job_check_time
-        while True:
-            time.sleep(async_job_check_time)
-            async_job_check_time = (async_job_check_time *
-                self._client.async_job_check_time_scale_percent / 100.0)
-            if async_job_check_time > self._client.async_job_check_max_time:
-                async_job_check_time = self._client.async_job_check_max_time
-            job_state = self._check_job(job_id)
-            if job_state['finished']:
-                return job_state['result'][0]
-
-    def _get_reads_set_v1_submit(self, params, context=None):
-        return self._client._submit_job(
-             'SetAPI.get_reads_set_v1', [params],
-             self._service_ver, context)
+        return self._client.call_method(
+            'SetAPI.save_reads_alignment_set_v1',
+            [params], self._service_ver, context)
 
     def get_reads_set_v1(self, params, context=None):
         """
@@ -1199,22 +1082,9 @@ class SetAPI(object):
            key-value pairs provided by the user.) -> mapping from String to
            String
         """
-        job_id = self._get_reads_set_v1_submit(params, context)
-        async_job_check_time = self._client.async_job_check_time
-        while True:
-            time.sleep(async_job_check_time)
-            async_job_check_time = (async_job_check_time *
-                self._client.async_job_check_time_scale_percent / 100.0)
-            if async_job_check_time > self._client.async_job_check_max_time:
-                async_job_check_time = self._client.async_job_check_max_time
-            job_state = self._check_job(job_id)
-            if job_state['finished']:
-                return job_state['result'][0]
-
-    def _save_reads_set_v1_submit(self, params, context=None):
-        return self._client._submit_job(
-             'SetAPI.save_reads_set_v1', [params],
-             self._service_ver, context)
+        return self._client.call_method(
+            'SetAPI.get_reads_set_v1',
+            [params], self._service_ver, context)
 
     def save_reads_set_v1(self, params, context=None):
         """
@@ -1326,22 +1196,9 @@ class SetAPI(object):
            key-value pairs provided by the user.) -> mapping from String to
            String
         """
-        job_id = self._save_reads_set_v1_submit(params, context)
-        async_job_check_time = self._client.async_job_check_time
-        while True:
-            time.sleep(async_job_check_time)
-            async_job_check_time = (async_job_check_time *
-                self._client.async_job_check_time_scale_percent / 100.0)
-            if async_job_check_time > self._client.async_job_check_max_time:
-                async_job_check_time = self._client.async_job_check_max_time
-            job_state = self._check_job(job_id)
-            if job_state['finished']:
-                return job_state['result'][0]
-
-    def _get_assembly_set_v1_submit(self, params, context=None):
-        return self._client._submit_job(
-             'SetAPI.get_assembly_set_v1', [params],
-             self._service_ver, context)
+        return self._client.call_method(
+            'SetAPI.save_reads_set_v1',
+            [params], self._service_ver, context)
 
     def get_assembly_set_v1(self, params, context=None):
         """
@@ -1450,22 +1307,9 @@ class SetAPI(object):
            key-value pairs provided by the user.) -> mapping from String to
            String
         """
-        job_id = self._get_assembly_set_v1_submit(params, context)
-        async_job_check_time = self._client.async_job_check_time
-        while True:
-            time.sleep(async_job_check_time)
-            async_job_check_time = (async_job_check_time *
-                self._client.async_job_check_time_scale_percent / 100.0)
-            if async_job_check_time > self._client.async_job_check_max_time:
-                async_job_check_time = self._client.async_job_check_max_time
-            job_state = self._check_job(job_id)
-            if job_state['finished']:
-                return job_state['result'][0]
-
-    def _save_assembly_set_v1_submit(self, params, context=None):
-        return self._client._submit_job(
-             'SetAPI.save_assembly_set_v1', [params],
-             self._service_ver, context)
+        return self._client.call_method(
+            'SetAPI.get_assembly_set_v1',
+            [params], self._service_ver, context)
 
     def save_assembly_set_v1(self, params, context=None):
         """
@@ -1574,22 +1418,9 @@ class SetAPI(object):
            key-value pairs provided by the user.) -> mapping from String to
            String
         """
-        job_id = self._save_assembly_set_v1_submit(params, context)
-        async_job_check_time = self._client.async_job_check_time
-        while True:
-            time.sleep(async_job_check_time)
-            async_job_check_time = (async_job_check_time *
-                self._client.async_job_check_time_scale_percent / 100.0)
-            if async_job_check_time > self._client.async_job_check_max_time:
-                async_job_check_time = self._client.async_job_check_max_time
-            job_state = self._check_job(job_id)
-            if job_state['finished']:
-                return job_state['result'][0]
-
-    def _get_genome_set_v1_submit(self, params, context=None):
-        return self._client._submit_job(
-             'SetAPI.get_genome_set_v1', [params],
-             self._service_ver, context)
+        return self._client.call_method(
+            'SetAPI.save_assembly_set_v1',
+            [params], self._service_ver, context)
 
     def get_genome_set_v1(self, params, context=None):
         """
@@ -1698,22 +1529,9 @@ class SetAPI(object):
            key-value pairs provided by the user.) -> mapping from String to
            String
         """
-        job_id = self._get_genome_set_v1_submit(params, context)
-        async_job_check_time = self._client.async_job_check_time
-        while True:
-            time.sleep(async_job_check_time)
-            async_job_check_time = (async_job_check_time *
-                self._client.async_job_check_time_scale_percent / 100.0)
-            if async_job_check_time > self._client.async_job_check_max_time:
-                async_job_check_time = self._client.async_job_check_max_time
-            job_state = self._check_job(job_id)
-            if job_state['finished']:
-                return job_state['result'][0]
-
-    def _save_genome_set_v1_submit(self, params, context=None):
-        return self._client._submit_job(
-             'SetAPI.save_genome_set_v1', [params],
-             self._service_ver, context)
+        return self._client.call_method(
+            'SetAPI.get_genome_set_v1',
+            [params], self._service_ver, context)
 
     def save_genome_set_v1(self, params, context=None):
         """
@@ -1822,22 +1640,9 @@ class SetAPI(object):
            key-value pairs provided by the user.) -> mapping from String to
            String
         """
-        job_id = self._save_genome_set_v1_submit(params, context)
-        async_job_check_time = self._client.async_job_check_time
-        while True:
-            time.sleep(async_job_check_time)
-            async_job_check_time = (async_job_check_time *
-                self._client.async_job_check_time_scale_percent / 100.0)
-            if async_job_check_time > self._client.async_job_check_max_time:
-                async_job_check_time = self._client.async_job_check_max_time
-            job_state = self._check_job(job_id)
-            if job_state['finished']:
-                return job_state['result'][0]
-
-    def _list_sets_submit(self, params, context=None):
-        return self._client._submit_job(
-             'SetAPI.list_sets', [params],
-             self._service_ver, context)
+        return self._client.call_method(
+            'SetAPI.save_genome_set_v1',
+            [params], self._service_ver, context)
 
     def list_sets(self, params, context=None):
         """
@@ -2007,22 +1812,9 @@ class SetAPI(object):
            the user.) -> mapping from String to String, parameter
            "raw_data_palette_refs" of mapping from String to String
         """
-        job_id = self._list_sets_submit(params, context)
-        async_job_check_time = self._client.async_job_check_time
-        while True:
-            time.sleep(async_job_check_time)
-            async_job_check_time = (async_job_check_time *
-                self._client.async_job_check_time_scale_percent / 100.0)
-            if async_job_check_time > self._client.async_job_check_max_time:
-                async_job_check_time = self._client.async_job_check_max_time
-            job_state = self._check_job(job_id)
-            if job_state['finished']:
-                return job_state['result'][0]
-
-    def _get_set_items_submit(self, params, context=None):
-        return self._client._submit_job(
-             'SetAPI.get_set_items', [params],
-             self._service_ver, context)
+        return self._client.call_method(
+            'SetAPI.list_sets',
+            [params], self._service_ver, context)
 
     def get_set_items(self, params, context=None):
         """
@@ -2131,28 +1923,10 @@ class SetAPI(object):
            the user.) -> mapping from String to String, parameter "dp_ref" of
            type "ws_obj_id" (The workspace ID for a any data object. @id ws)
         """
-        job_id = self._get_set_items_submit(params, context)
-        async_job_check_time = self._client.async_job_check_time
-        while True:
-            time.sleep(async_job_check_time)
-            async_job_check_time = (async_job_check_time *
-                self._client.async_job_check_time_scale_percent / 100.0)
-            if async_job_check_time > self._client.async_job_check_max_time:
-                async_job_check_time = self._client.async_job_check_max_time
-            job_state = self._check_job(job_id)
-            if job_state['finished']:
-                return job_state['result'][0]
+        return self._client.call_method(
+            'SetAPI.get_set_items',
+            [params], self._service_ver, context)
 
     def status(self, context=None):
-        job_id = self._client._submit_job('SetAPI.status', 
-            [], self._service_ver, context)
-        async_job_check_time = self._client.async_job_check_time
-        while True:
-            time.sleep(async_job_check_time)
-            async_job_check_time = (async_job_check_time *
-                self._client.async_job_check_time_scale_percent / 100.0)
-            if async_job_check_time > self._client.async_job_check_max_time:
-                async_job_check_time = self._client.async_job_check_max_time
-            job_state = self._check_job(job_id)
-            if job_state['finished']:
-                return job_state['result'][0]
+        return self._client.call_method('SetAPI.status',
+                                        [], self._service_ver, context)

--- a/lib/kb_cufflinks/core/cufflinks_utils.py
+++ b/lib/kb_cufflinks/core/cufflinks_utils.py
@@ -759,82 +759,34 @@ class CufflinksUtils:
 
         return expression_set_data
 
-    def _process_rnaseq_alignment_set_object(self, params):
+    def _process_alignment_set_object(self, params, alignment_object_type):
         """
         _process_alignment_set_object: process KBaseRNASeq.RNASeqAlignmentSet type input object
+                                        and KBaseSets.ReadsAlignmentSet type object
         """
-        log('start processing KBaseRNASeq.RNASeqAlignmentSet object\nparams:\n{}'.format(
+        log('start processing KBaseRNASeq.RNASeqAlignmentSet object or KBaseSets.ReadsAlignmentSet object'
+            '\nparams:\n{}'.format(
             json.dumps(params, indent=1)))
 
         alignment_set_ref = params.get('alignment_set_ref')
 
-        params['gtf_file'] = self._get_gtf_file(alignment_set_ref)
+        if re.match('^KBaseRNASeq.RNASeqAlignmentSet-\d*', alignment_object_type):
+            params['gtf_file'] = self._get_gtf_file(alignment_set_ref)
+        else:
+            if not '/' in params['genome_ref']:
+                params['genome_ref'] = params['workspace_name']+'/'+params['genome_ref']
 
-        alignment_set_data = self.ws.get_objects2({'objects':
-                                                   [{'ref': alignment_set_ref}]})['data'][0]['data']
+            params['gtf_file'] = self._get_gtf_file_from_genome_ref(params['genome_ref'])
 
-        mapped_alignment_ids = alignment_set_data['mapped_alignments_ids']
+        alignment_set = self.set_api.get_reads_alignment_set_v1({
+                                            'ref': alignment_set_ref,
+                                            'include_item_info': 0
+                                            })
         mul_processor_params = []
-        for i in mapped_alignment_ids:
-            for sample_name, alignment_id in i.items():
-                aliment_upload_params = params.copy()
-                aliment_upload_params['alignment_ref'] = alignment_id
-                mul_processor_params.append(aliment_upload_params)
-
-        cpus = min(params.get('num_threads'), multiprocessing.cpu_count())
-        pool = Pool(ncpus=cpus)
-        log('running _process_alignment_object with {} cpus'.format(cpus))
-        alignment_expression_map = pool.map(self._process_rnaseq_alignment_object, mul_processor_params)
-
-        result_directory = os.path.join(self.scratch, str(uuid.uuid4()))
-        self._mkdir_p(result_directory)
-
-        for proc_alignment_return in alignment_expression_map:
-            expression_obj_ref = proc_alignment_return.get('expression_obj_ref')
-            expression_name = self.ws.get_object_info([{"ref": expression_obj_ref}],
-                                                      includeMetadata=None)[0][1]
-            self._run_command('cp -R {} {}'.format(proc_alignment_return.get('result_directory'),
-                                                   os.path.join(result_directory, expression_name)))
-
-        expression_obj_ref = self._save_rnaseq_expression_set(alignment_expression_map,
-                                                       alignment_set_ref,
-                                                       params.get('workspace_name'),
-                                                       params.get('expression_set_name'))
-
-        returnVal = {'result_directory': result_directory,
-                     'expression_obj_ref': expression_obj_ref}
-
-        expression_set_name = self.ws.get_object_info([{"ref": expression_obj_ref}],
-                                                      includeMetadata=None)[0][1]
-
-        widget_params = {"output": expression_set_name, "workspace": params.get('workspace_name')}
-        returnVal.update(widget_params)
-
-        return returnVal
-
-
-    def _process_kbasesets_alignment_set_object(self, params):
-        """
-        _process_alignment_set_object: process KBaseSets.ReadsAlignmentSet type input object
-        """
-        log('start processing KBaseSets.ReadsAlignmentSet object\nparams:\n{}'.format(
-            json.dumps(params, indent=1)))
-
-        alignment_set_ref = params.get('alignment_set_ref')
-
-        if not '/' in params['genome_ref']:
-            params['genome_ref'] = params['workspace_name']+'/'+params['genome_ref']
-
-        params['gtf_file'] = self._get_gtf_file_from_genome_ref(params['genome_ref'])
-
-        alignment_set_data = self.ws.get_objects2({'objects':
-                                                   [{'ref': alignment_set_ref}]})['data'][0]['data']
-
-        alignment_items = alignment_set_data['items']
-        mul_processor_params = []
-        for item in alignment_items:
+        for alignment in alignment_set["data"]["items"]:
+            alignment_ref = alignment['ref']
             alignment_upload_params = params.copy()
-            alignment_upload_params['alignment_ref'] = item['ref']
+            alignment_upload_params['alignment_ref'] = alignment_ref
             mul_processor_params.append(alignment_upload_params)
 
         cpus = min(params.get('num_threads'), multiprocessing.cpu_count())
@@ -849,7 +801,7 @@ class CufflinksUtils:
         for proc_alignment_return in alignment_expression_map:
             expression_obj_ref = proc_alignment_return.get('expression_obj_ref')
             alignment_ref = proc_alignment_return.get('alignment_ref')
-            condition = self.ws.get_object_info([{"ref": alignment_ref}],includeMetadata=1)[0][10]['condition']
+            condition = self.ws.get_object_info([{"ref": alignment_ref}], includeMetadata=1)[0][10]['condition']
             expression_items.append({
                 "ref": expression_obj_ref,
                 "label": condition,
@@ -877,7 +829,6 @@ class CufflinksUtils:
         returnVal.update(widget_params)
 
         return returnVal
-
 
     def _generate_output_object_name(self, params, alignment_object_type, alignment_object_name):
         """
@@ -945,10 +896,6 @@ class CufflinksUtils:
         log('--->\nrunning CufflinksUtil.run_cufflinks_app\n' +
             'params:\n{}'.format(json.dumps(params, indent=1)))
 
-        #dummy call to dfu to cache the beta version of callback server
-        ws_id = self.dfu.ws_name_to_id(params['workspace_name'])
-        print('ws_id: '+str(ws_id))
-
         self._validate_run_cufflinks_params(params)
 
         alignment_object_ref = params.get('alignment_object_ref')
@@ -971,26 +918,12 @@ class CufflinksUtils:
                                                   params.get('workspace_name'),
                                                   returnVal.get('result_directory'))
             returnVal.update(report_output)
-        elif re.match('^KBaseRNASeq.RNASeqAlignmentSet-\d*', alignment_object_type):
+        elif re.match('^KBaseRNASeq.RNASeqAlignmentSet-\d*', alignment_object_type) or \
+             re.match('^KBaseSets.ReadsAlignmentSet-\d*', alignment_object_type):
             params.update({'alignment_set_ref': alignment_object_ref})
-            returnVal = self._process_rnaseq_alignment_set_object(params)
+            returnVal = self._process_alignment_set_object(params, alignment_object_type)
             expression_matrix_refs = self._save_expression_matrix(returnVal['expression_obj_ref'],
                                                                   params.get('workspace_name'))
-
-            returnVal.update(expression_matrix_refs)
-
-            report_output = self._generate_report(returnVal['expression_obj_ref'],
-                                                  params.get('workspace_name'),
-                                                  returnVal['result_directory'],
-                                                  expression_matrix_refs['exprMatrix_FPKM_ref'],
-                                                  expression_matrix_refs['exprMatrix_TPM_ref'])
-            returnVal.update(report_output)
-        elif re.match('^KBaseSets.ReadsAlignmentSet-\d*', alignment_object_type):
-            params.update({'alignment_set_ref': alignment_object_ref})
-            returnVal = self._process_kbasesets_alignment_set_object(params)
-            expression_matrix_refs = self._save_expression_matrix(returnVal['expression_obj_ref'],
-                                                                  params.get('workspace_name'))
-
             returnVal.update(expression_matrix_refs)
 
             report_output = self._generate_report(returnVal['expression_obj_ref'],
@@ -1002,6 +935,5 @@ class CufflinksUtils:
         else:
             raise ValueError('None RNASeqAlignment type\nObject info:\n{}'.format(
                 alignment_object_info))
-
 
         return returnVal

--- a/lib/kb_cufflinks/core/cufflinks_utils.py
+++ b/lib/kb_cufflinks/core/cufflinks_utils.py
@@ -44,14 +44,15 @@ class CufflinksUtils:
         self.ws_url = config["workspace-url"]
         self.ws_url = config["workspace-url"]
         self.callback_url = config['SDK_CALLBACK_URL']
+        self.srv_wiz_url = config['srv-wiz-url']
         self.token = config['KB_AUTH_TOKEN']
         self.shock_url = config['shock-url']
-        self.dfu = DataFileUtil(self.callback_url, service_ver='beta')
+        self.dfu = DataFileUtil(self.callback_url)
         self.gfu = GenomeFileUtil(self.callback_url)
         self.au = AssemblyUtil(self.callback_url)
-        self.rau = ReadsAlignmentUtils(self.callback_url, service_ver='beta')
-        self.set_api = SetAPI(self.callback_url)
-        self.eu = ExpressionUtils(self.callback_url, service_ver='beta')
+        self.rau = ReadsAlignmentUtils(self.callback_url)
+        self.set_api = SetAPI(self.srv_wiz_url)
+        self.eu = ExpressionUtils(self.callback_url)
         self.ws = Workspace(self.ws_url, token=self.token)
 
         self.scratch = os.path.join(config['scratch'], str(uuid.uuid4()))

--- a/test/cufflinks_test.py
+++ b/test/cufflinks_test.py
@@ -56,13 +56,13 @@ class CufflinksTest(unittest.TestCase):
         cls.serviceImpl = kb_cufflinks(cls.cfg)
         cls.scratch = cls.cfg['scratch']
         cls.callback_url = environ.get('SDK_CALLBACK_URL')
+        cls.srv_wiz_url = cls.cfg['srv-wiz-url']
 
         # cls.wsName = 'cufflinks_test_' + user_id  # reuse existing workspace
-#        suffix = int(time.time() * 1000)
-        suffix = 1009
+#       suffix = int(time.time() * 1000)
+        suffix = 1509715902867  #1009
         cls.wsName = "test_kb_cufflinks_" + str(suffix)
         print('workspace_name: ' + cls.wsName)
-
 
         try:
             # reuse existing (previously torn down) workspace
@@ -79,13 +79,11 @@ class CufflinksTest(unittest.TestCase):
                 print("creating new workspace: " + str(ws_info))
 
         cls.dfu = DataFileUtil(cls.callback_url)
-        # dummy call to dfu to cache the beta version of callback server
-        ws_id = cls.dfu.ws_name_to_id(cls.wsName)
-        print('test ws_id: ' + str(ws_id))
+
         cls.gfu = GenomeFileUtil(cls.callback_url)
         cls.ru = ReadsUtils(cls.callback_url)
-        cls.rau = ReadsAlignmentUtils(cls.callback_url, service_ver='beta')
-        cls.set_api = SetAPI(cls.callback_url)
+        cls.rau = ReadsAlignmentUtils(cls.callback_url)
+        cls.set_api = SetAPI(cls.srv_wiz_url)
 
         cls.cufflinks_runner = CufflinksUtils(cls.cfg)
 

--- a/test/cufflinks_test.py
+++ b/test/cufflinks_test.py
@@ -4,6 +4,7 @@ import unittest
 import os  # noqa: F401
 import time
 import shutil
+from pprint import pprint
 
 from GenomeFileUtil.GenomeFileUtilClient import GenomeFileUtil
 from ReadsUtils.ReadsUtilsClient import ReadsUtils
@@ -260,7 +261,6 @@ class CufflinksTest(unittest.TestCase):
             "overhang_tolerance": 8,
             "num_threads": 1
         }
-
         result = self.getImpl().run_cufflinks(self.ctx, params)[0]
 
         self.assertTrue('result_directory' in result)
@@ -302,9 +302,11 @@ class CufflinksTest(unittest.TestCase):
         self.assertTrue('report_ref' in result)
         expression_data = self.getWsClient().get_objects([{'objid': int(result.get(
             'expression_obj_ref').split('/')[1]), 'workspace': self.__class__.wsName}])[0]['data']
-        self.assertEqual(expression_data.get('genome_id'), self.genome_ref)
-        self.assertEqual(expression_data.get('sampleset_id'), self.sample_set_ref)
-        self.assertEqual(expression_data.get('id'), 'test_expression_set')
+
+        pprint(expression_data.get('items')[0]['label'])
+        pprint(expression_data.get('items')[1]['label'])
+        self.assertTrue(expression_data.get('items')[0]['label'].startswith('test_condition_'))
+        self.assertTrue(expression_data.get('items')[1]['label'].startswith('test_condition_'))
         self.assertTrue('exprMatrix_FPKM_ref' in result)
         self.assertTrue('exprMatrix_TPM_ref' in result)
 
@@ -386,3 +388,4 @@ class CufflinksTest(unittest.TestCase):
         self.assertTrue(expression_data.get('items')[1]['label'].startswith('test_condition_'))
         self.assertTrue('exprMatrix_FPKM_ref' in result)
         self.assertTrue('exprMatrix_TPM_ref' in result)
+

--- a/test/cufflinks_test.py
+++ b/test/cufflinks_test.py
@@ -84,7 +84,7 @@ class CufflinksTest(unittest.TestCase):
         cls.gfu = GenomeFileUtil(cls.callback_url)
         cls.ru = ReadsUtils(cls.callback_url)
         cls.rau = ReadsAlignmentUtils(cls.callback_url)
-        cls.set_api = SetAPI(cls.srv_wiz_url)
+        cls.set_api = SetAPI(cls.srv_wiz_url, service_ver='dev')
 
         cls.cufflinks_runner = CufflinksUtils(cls.cfg)
 


### PR DESCRIPTION
Changes:
- To use SetAPI as a dynamic service
- To use the SetAPI call, get_reads_alignment_set_v1() to get data from both KBaseSets and RNASeq  type alignment set inputs
- To use ref chains for alignment objects in input sets
- Updated version
- Updated Release Notes
